### PR TITLE
multi-services: Add com.endlessm.EknServicesMultiplexer flatpak

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,58 @@
+# Copyright (C) 2016-2018 Endless Mobile, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# All rights reserved.
+
+BUILT_SOURCES =
+CLEANFILES =
+MAINTAINERCLEANFILES = $(GITIGNORE_MAINTAINERCLEANFILES_TOPLEVEL)
+EXTRA_DIST =
+
+# # # SUBSTITUTED FILES # # #
+# These files need to be filled in with make variables
+do_subst = $(SED) -e 's|%bindir%|$(bindir)|g' -e 's|%arch%|$(UNAME_ARCH)|g'
+subst_files = \
+	data/com.endlessm.EknServices.SearchProviderV1.service \
+	data/com.endlessm.EknServices2.SearchProviderV2.service \
+	$(NULL)
+
+$(subst_files): %: %.in Makefile
+	$(AM_V_GEN)$(MKDIR_P) $(@D) && \
+	$(do_subst) $< > $@
+
+CLEANFILES += $(subst_files)
+EXTRA_DIST += $(patsubst %,%.in,$(subst_files))
+
+bin_PROGRAMS = eks-multi-search-provider-dispatcher
+eks_multi_search_provider_dispatcher_SOURCES = \
+	multi-services/eks-multi-search-provider-dispatcher.c \
+	$(NULL)
+eks_multi_search_provider_dispatcher_CFLAGS = \
+	$(MULTI_SERVICES_CFLAGS) \
+	-I $(builddir)/multi-search-provider \
+	$(AM_CFLAGS) \
+	$(NULL)
+eks_multi_search_provider_dispatcher_LDADD = \
+	$(MULTI_SERVICES_LIBS) \
+	$(NULL)
+
+servicedir = $(datadir)/dbus-1/services
+service_DATA = \
+	data/com.endlessm.EknServices.SearchProviderV1.service \
+	data/com.endlessm.EknServices2.SearchProviderV2.service \
+	$(NULL)
+
+-include $(top_srcdir)/git.mk
+

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Bootstrap script for eos-knowledge-services
+# Run this script on a clean source checkout to get ready for building.
+
+test -n "$srcdir" || srcdir=`dirname "$0"`
+test -n "$srcdir" || srcdir=.
+olddir=`pwd`
+
+cd $srcdir
+test -f configure.ac || {
+    echo "You must run this script in the top-level checkout directory"
+    exit 1
+}
+
+# NOCONFIGURE is used by gnome-common
+if test -z "$NOCONFIGURE"; then
+    echo "This script will run ./configure automatically. If you wish to pass "
+    echo "any arguments to it, please specify them on the $0 "
+    echo "command line. To disable this behavior, have NOCONFIGURE=1 in your "
+    echo "environment."
+fi
+
+# Run the actual tools to prepare the clean checkout
+mkdir -p m4
+autoreconf -fi || exit $?
+
+cd "$olddir"
+test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"

--- a/com.endlessm.BaseEknServicesMultiplexer.json.in
+++ b/com.endlessm.BaseEknServicesMultiplexer.json.in
@@ -1,0 +1,27 @@
+{
+    "app-id": "com.endlessm.BaseEknServicesMultiplexer",
+    "branch": "@BRANCH@",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "1.6",
+    "sdk": "org.freedesktop.Sdk",
+    "add-extensions": {
+        "com.endlessm.EknServices.Extension": {
+            "directory": "build/eos-knowledge-services/1",
+            "version": "eos3"
+        },
+        "com.endlessm.EknServices2.Extension": {
+            "directory": "build/eos-knowledge-services/2",
+            "version": "@BRANCH@"
+        }
+    },
+    "modules": [
+        {
+            "name": "multi-eos-knowledge-services-directories",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /app/build/eos-knowledge-services/1",
+                "mkdir -p /app/build/eos-knowledge-services/2"
+            ]
+        }
+    ]
+}

--- a/com.endlessm.EknServicesMultiplexer.json.in
+++ b/com.endlessm.EknServicesMultiplexer.json.in
@@ -1,0 +1,75 @@
+{
+    "app-id": "com.endlessm.EknServicesMultiplexer",
+    "base": "com.endlessm.BaseEknServicesMultiplexer",
+    "base-extensions": [
+        "com.endlessm.EknServices.Extension",
+        "com.endlessm.EknServices2.Extension"
+    ],
+    "branch": "@BRANCH@",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "1.6",
+    "sdk": "org.freedesktop.Sdk",
+    "finish-args": [
+        "--filesystem=/var/lib/flatpak:ro",
+        "--filesystem=/var/endless-extra/flatpak:ro",
+        "--filesystem=~/.local/share/flatpak:ro",
+        "--filesystem=~/.local/share",
+        "--env=EKN_SUBSCRIPTIONS_DIR=.local/share/com.endlessm.subscriptions",
+        "--share=network",
+        "--socket=session-bus",
+        "--own-name=com.endlessm.EknServices.SearchProviderV1",
+        "--own-name=com.endlessm.EknServices2.SearchProviderV2"
+    ],
+    "add-extensions": {
+        "com.endlessm.Platform": {
+            "directory": "sdk/0",
+            "no-autodownload": true,
+            "versions": "eos3.1;eos3.0"
+        },
+        "com.endlessm.apps.Platform@1": {
+            "directory": "sdk/1",
+            "no-autodownload": true,
+            "version": "1"
+        },
+        "com.endlessm.apps.Platform@2": {
+            "directory": "sdk/2",
+            "no-autodownload": true,
+            "version": "2"
+        },
+        "com.endlessm.apps.Platform": {
+            "directory": "sdk/3",
+            "no-autodownload": true,
+            "version": "3"
+        }
+    },
+    "modules": [
+        {
+            "name": "eos-knowledge-services-multiplexer",
+            "sources": [
+                {
+                    "type": "git",
+                    "path": ".",
+                    "branch": "@GIT_CLONE_BRANCH@"
+                }
+            ]
+        },
+        {
+            "name": "multi-eos-knowledge-services-directories",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /app/sdk/0",
+                "mkdir -p /app/sdk/1",
+                "mkdir -p /app/sdk/2",
+                "mkdir -p /app/sdk/3",
+                "mkdir -p /app/eos-knowledge-services/",
+                "mkdir -p /app/lib/debug/eos-knowledge-services",
+                "cp -r /app/build/eos-knowledge-services/1 /app/eos-knowledge-services/1",
+                "mv /app/eos-knowledge-services/1/lib/debug /app/lib/debug/eos-knowledge-services/1",
+                "ln -s /app/eos-knowledge-services/1/bin/eks-search-provider-v1 /app/bin/eks-search-provider-v1",
+                "cp -r /app/build/eos-knowledge-services/2 /app/eos-knowledge-services/2",
+                "mv /app/eos-knowledge-services/2/lib/debug /app/lib/debug/eos-knowledge-services/2",
+                "ln -s /app/eos-knowledge-services/2/bin/eks-search-provider-v2 /app/bin/eks-search-provider-v2"
+            ]
+        }
+    ]
+}

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,77 @@
+# Process this file with autoconf to produce configure
+
+# Copyright 2018 Endless Mobile, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# All rights reserved.
+
+# ------------
+# configure.ac
+# ------------
+# Please keep this file well-commented. Autotools involve a lot of magical
+# incantations, and it is easy to mess things up if you don't know what you
+# are doing.
+
+# Initialization
+# --------------
+# Initialize Autoconf: package name, version, bug report address, tarball name,
+# website
+AC_INIT([Endless OS Knowledge Services Multiplexer], [0],
+    [], [eos-knowledge-services-multiplexer], [http://endlessm.com])
+# Initialize Automake: enable all warnings and do not insist on GNU standards
+# no-portability suppresses warnings about syntax specific to GNU make
+AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign 1.11 tar-ustar subdir-objects])
+# Avoid spewing garbage over the terminal ('make V=1' to see the garbage)
+AM_SILENT_RULES([yes])
+# Keep Autotools macros local to this source tree
+AC_CONFIG_MACRO_DIR([m4])
+
+AC_CACHE_SAVE
+
+# Required build tools
+# --------------------
+# Make sure we can create directory hierarchies
+AC_PROG_MKDIR_P
+# Needed for paths substitutions
+AC_PROG_SED
+# C compiler
+AC_PROG_CC
+AC_PROG_CC_C99
+# Library configuration tool
+PKG_PROG_PKG_CONFIG
+
+# Flatpak
+UNAME_ARCH=$(uname -p)
+AC_SUBST([UNAME_ARCH])
+
+# Only need glib and gio for the multi-services binary
+PKG_CHECK_MODULES([MULTI_SERVICES], [
+  gio-2.0
+  glib-2.0
+  gobject-2.0
+])
+
+AC_CACHE_SAVE
+
+# Output
+# ------
+# List files here that the configure script should output
+
+AC_CONFIG_FILES([
+  Makefile
+])
+
+# Do the output
+AC_OUTPUT

--- a/data/com.endlessm.EknServices.SearchProviderV1.service.in
+++ b/data/com.endlessm.EknServices.SearchProviderV1.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.endlessm.EknServices.SearchProviderV1
+Exec=%bindir%/eks-multi-search-provider-dispatcher --services-version 1 --arch %arch%

--- a/data/com.endlessm.EknServices2.SearchProviderV2.service.in
+++ b/data/com.endlessm.EknServices2.SearchProviderV2.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.endlessm.EknServices2.SearchProviderV2
+Exec=%bindir%/eks-multi-search-provider-dispatcher --services-version 2 --arch %arch%

--- a/git.mk
+++ b/git.mk
@@ -1,0 +1,400 @@
+# git.mk, a small Makefile to autogenerate .gitignore files
+# for autotools-based projects.
+#
+# Copyright 2009, Red Hat, Inc.
+# Copyright 2010,2011,2012,2013 Behdad Esfahbod
+# Written by Behdad Esfahbod
+#
+# Copying and distribution of this file, with or without modification,
+# is permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.
+#
+# The latest version of this file can be downloaded from:
+GIT_MK_URL = https://raw.githubusercontent.com/behdad/git.mk/master/git.mk
+#
+# Bugs, etc, should be reported upstream at:
+#   https://github.com/behdad/git.mk
+#
+# To use in your project, import this file in your git repo's toplevel,
+# then do "make -f git.mk".  This modifies all Makefile.am files in
+# your project to -include git.mk.  Remember to add that line to new
+# Makefile.am files you create in your project, or just rerun the
+# "make -f git.mk".
+#
+# This enables automatic .gitignore generation.  If you need to ignore
+# more files, add them to the GITIGNOREFILES variable in your Makefile.am.
+# But think twice before doing that.  If a file has to be in .gitignore,
+# chances are very high that it's a generated file and should be in one
+# of MOSTLYCLEANFILES, CLEANFILES, DISTCLEANFILES, or MAINTAINERCLEANFILES.
+#
+# The only case that you need to manually add a file to GITIGNOREFILES is
+# when remove files in one of mostlyclean-local, clean-local, distclean-local,
+# or maintainer-clean-local make targets.
+#
+# Note that for files like editor backup, etc, there are better places to
+# ignore them.  See "man gitignore".
+#
+# If "make maintainer-clean" removes the files but they are not recognized
+# by this script (that is, if "git status" shows untracked files still), send
+# me the output of "git status" as well as your Makefile.am and Makefile for
+# the directories involved and I'll diagnose.
+#
+# For a list of toplevel files that should be in MAINTAINERCLEANFILES, see
+# Makefile.am.sample in the git.mk git repo.
+#
+# Don't EXTRA_DIST this file.  It is supposed to only live in git clones,
+# not tarballs.  It serves no useful purpose in tarballs and clutters the
+# build dir.
+#
+# This file knows how to handle autoconf, automake, libtool, gtk-doc,
+# gnome-doc-utils, yelp.m4, mallard, intltool, gsettings, dejagnu, appdata,
+# appstream, hotdoc.
+#
+# This makefile provides the following targets:
+#
+# - all: "make all" will build all gitignore files.
+# - gitignore: makes all gitignore files in the current dir and subdirs.
+# - .gitignore: make gitignore file for the current dir.
+# - gitignore-recurse: makes all gitignore files in the subdirs.
+#
+# KNOWN ISSUES:
+#
+# - Recursive configure doesn't work as $(top_srcdir)/git.mk inside the
+#   submodule doesn't find us.  If you have configure.{in,ac} files in
+#   subdirs, add a proxy git.mk file in those dirs that simply does:
+#   "include $(top_srcdir)/../git.mk".  Add more ..'s to your taste.
+#   And add those files to git.  See vte/gnome-pty-helper/git.mk for
+#   example.
+#
+
+
+
+###############################################################################
+# Variables user modules may want to add to toplevel MAINTAINERCLEANFILES:
+###############################################################################
+
+#
+# Most autotools-using modules should be fine including this variable in their
+# toplevel MAINTAINERCLEANFILES:
+GITIGNORE_MAINTAINERCLEANFILES_TOPLEVEL = \
+	$(srcdir)/aclocal.m4 \
+	$(srcdir)/autoscan.log \
+	$(srcdir)/configure.scan \
+	`AUX_DIR=$(srcdir)/$$(cd $(top_srcdir); $(AUTOCONF) --trace 'AC_CONFIG_AUX_DIR:$$1' ./configure.ac); \
+	 test "x$$AUX_DIR" = "x$(srcdir)/" && AUX_DIR=$(srcdir); \
+	 for x in \
+		ar-lib \
+		compile \
+		config.guess \
+		config.rpath \
+		config.sub \
+		depcomp \
+		install-sh \
+		ltmain.sh \
+		missing \
+		mkinstalldirs \
+		test-driver \
+		ylwrap \
+	 ; do echo "$$AUX_DIR/$$x"; done` \
+	`cd $(top_srcdir); $(AUTOCONF) --trace 'AC_CONFIG_HEADERS:$$1' ./configure.ac | \
+	head -n 1 | while read f; do echo "$(srcdir)/$$f.in"; done`
+#
+# All modules should also be fine including the following variable, which
+# removes automake-generated Makefile.in files:
+GITIGNORE_MAINTAINERCLEANFILES_MAKEFILE_IN = \
+	`cd $(top_srcdir); $(AUTOCONF) --trace 'AC_CONFIG_FILES:$$1' ./configure.ac | \
+	while read f; do \
+	  case $$f in Makefile|*/Makefile) \
+	    test -f "$(srcdir)/$$f.am" && echo "$(srcdir)/$$f.in";; esac; \
+	done`
+#
+# Modules that use libtool and use  AC_CONFIG_MACRO_DIR() may also include this,
+# though it's harmless to include regardless.
+GITIGNORE_MAINTAINERCLEANFILES_M4_LIBTOOL = \
+	`MACRO_DIR=$(srcdir)/$$(cd $(top_srcdir); $(AUTOCONF) --trace 'AC_CONFIG_MACRO_DIR:$$1' ./configure.ac); \
+	 if test "x$$MACRO_DIR" != "x$(srcdir)/"; then \
+		for x in \
+			libtool.m4 \
+			ltoptions.m4 \
+			ltsugar.m4 \
+			ltversion.m4 \
+			lt~obsolete.m4 \
+		; do echo "$$MACRO_DIR/$$x"; done; \
+	 fi`
+#
+# Modules that use gettext and use  AC_CONFIG_MACRO_DIR() may also include this,
+# though it's harmless to include regardless.
+GITIGNORE_MAINTAINERCLEANFILES_M4_GETTEXT = \
+	`MACRO_DIR=$(srcdir)/$$(cd $(top_srcdir); $(AUTOCONF) --trace 'AC_CONFIG_MACRO_DIR:$$1' ./configure.ac); \
+	if test "x$$MACRO_DIR" != "x$(srcdir)/"; then	\
+		for x in				\
+			codeset.m4			\
+			extern-inline.m4		\
+			fcntl-o.m4			\
+			gettext.m4			\
+			glibc2.m4			\
+			glibc21.m4			\
+			iconv.m4			\
+			intdiv0.m4			\
+			intl.m4				\
+			intldir.m4			\
+			intlmacosx.m4			\
+			intmax.m4			\
+			inttypes-pri.m4			\
+			inttypes_h.m4			\
+			lcmessage.m4			\
+			lib-ld.m4			\
+			lib-link.m4			\
+			lib-prefix.m4			\
+			lock.m4				\
+			longlong.m4			\
+			nls.m4				\
+			po.m4				\
+			printf-posix.m4			\
+			progtest.m4			\
+			size_max.m4			\
+			stdint_h.m4			\
+			threadlib.m4			\
+			uintmax_t.m4			\
+			visibility.m4			\
+			wchar_t.m4			\
+			wint_t.m4			\
+			xsize.m4			\
+		; do echo "$$MACRO_DIR/$$x"; done; \
+	fi`
+
+
+
+###############################################################################
+# Default rule is to install ourselves in all Makefile.am files:
+###############################################################################
+
+git-all: git-mk-install
+
+git-mk-install:
+	@echo "Installing git makefile"
+	@any_failed=; \
+		find "`test -z "$(top_srcdir)" && echo . || echo "$(top_srcdir)"`" -name Makefile.am | while read x; do \
+		if grep 'include .*/git.mk' $$x >/dev/null; then \
+			echo "$$x already includes git.mk"; \
+		else \
+			failed=; \
+			echo "Updating $$x"; \
+			{ cat $$x; \
+			  echo ''; \
+			  echo '-include $$(top_srcdir)/git.mk'; \
+			} > $$x.tmp || failed=1; \
+			if test x$$failed = x; then \
+				mv $$x.tmp $$x || failed=1; \
+			fi; \
+			if test x$$failed = x; then : else \
+				echo "Failed updating $$x"; >&2 \
+				any_failed=1; \
+			fi; \
+	fi; done; test -z "$$any_failed"
+
+git-mk-update:
+	wget $(GIT_MK_URL) -O $(top_srcdir)/git.mk
+
+.PHONY: git-all git-mk-install git-mk-update
+
+
+
+###############################################################################
+# Actual .gitignore generation:
+###############################################################################
+
+$(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
+	@echo "git.mk: Generating $@"
+	@{ \
+		if test "x$(DOC_MODULE)" = x -o "x$(DOC_MAIN_SGML_FILE)" = x; then :; else \
+			for x in \
+				$(DOC_MODULE)-decl-list.txt \
+				$(DOC_MODULE)-decl.txt \
+				tmpl/$(DOC_MODULE)-unused.sgml \
+				"tmpl/*.bak" \
+				$(REPORT_FILES) \
+				$(DOC_MODULE).pdf \
+				xml html \
+			; do echo "/$$x"; done; \
+			FLAVOR=$$(cd $(top_srcdir); $(AUTOCONF) --trace 'GTK_DOC_CHECK:$$2' ./configure.ac); \
+			case $$FLAVOR in *no-tmpl*) echo /tmpl;; esac; \
+			if echo "$(SCAN_OPTIONS)" | grep -q "\-\-rebuild-types"; then \
+				echo "/$(DOC_MODULE).types"; \
+			fi; \
+			if echo "$(SCAN_OPTIONS)" | grep -q "\-\-rebuild-sections"; then \
+				echo "/$(DOC_MODULE)-sections.txt"; \
+			fi; \
+			if test "$(abs_srcdir)" != "$(abs_builddir)" ; then \
+				for x in \
+					$(SETUP_FILES) \
+					$(DOC_MODULE).types \
+				; do echo "/$$x"; done; \
+			fi; \
+		fi; \
+		if test "x$(DOC_MODULE)$(DOC_ID)" = x -o "x$(DOC_LINGUAS)" = x; then :; else \
+			for lc in $(DOC_LINGUAS); do \
+				for x in \
+					$(if $(DOC_MODULE),$(DOC_MODULE).xml) \
+					$(DOC_PAGES) \
+					$(DOC_INCLUDES) \
+				; do echo "/$$lc/$$x"; done; \
+			done; \
+			for x in \
+				$(_DOC_OMF_ALL) \
+				$(_DOC_DSK_ALL) \
+				$(_DOC_HTML_ALL) \
+				$(_DOC_MOFILES) \
+				$(DOC_H_FILE) \
+				"*/.xml2po.mo" \
+				"*/*.omf.out" \
+			; do echo /$$x; done; \
+		fi; \
+		if test "x$(HOTDOC)" = x; then :; else \
+			$(foreach project, $(HOTDOC_PROJECTS),echo "/$(call HOTDOC_TARGET,$(project))"; \
+				echo "/$(shell $(call HOTDOC_PROJECT_COMMAND,$(project)) --get-conf-path output)" ; \
+				echo "/$(shell $(call HOTDOC_PROJECT_COMMAND,$(project)) --get-private-folder)" ; \
+			) \
+			for x in \
+				.hotdoc.d \
+			; do echo "/$$x"; done; \
+		fi; \
+		if test "x$(HELP_ID)" = x -o "x$(HELP_LINGUAS)" = x; then :; else \
+			for lc in $(HELP_LINGUAS); do \
+				for x in \
+					$(HELP_FILES) \
+					"$$lc.stamp" \
+					"$$lc.mo" \
+				; do echo "/$$lc/$$x"; done; \
+			done; \
+		fi; \
+		if test "x$(gsettings_SCHEMAS)" = x; then :; else \
+			for x in \
+				$(gsettings_SCHEMAS:.xml=.valid) \
+				$(gsettings__enum_file) \
+			; do echo "/$$x"; done; \
+		fi; \
+		if test "x$(appdata_XML)" = x; then :; else \
+			for x in \
+				$(appdata_XML:.xml=.valid) \
+			; do echo "/$$x"; done; \
+		fi; \
+		if test "x$(appstream_XML)" = x; then :; else \
+			for x in \
+				$(appstream_XML:.xml=.valid) \
+			; do echo "/$$x"; done; \
+		fi; \
+		if test -f $(srcdir)/po/Makefile.in.in; then \
+			for x in \
+				ABOUT-NLS \
+				po/Makefile.in.in \
+				po/Makefile.in.in~ \
+				po/Makefile.in \
+				po/Makefile \
+				po/Makevars.template \
+				po/POTFILES \
+				po/Rules-quot \
+				po/stamp-it \
+				po/stamp-po \
+				po/.intltool-merge-cache \
+				"po/*.gmo" \
+				"po/*.header" \
+				"po/*.mo" \
+				"po/*.sed" \
+				"po/*.sin" \
+				po/$(GETTEXT_PACKAGE).pot \
+				intltool-extract.in \
+				intltool-merge.in \
+				intltool-update.in \
+			; do echo "/$$x"; done; \
+		fi; \
+		if test -f $(srcdir)/configure; then \
+			for x in \
+				autom4te.cache \
+				configure \
+				config.h \
+				stamp-h1 \
+				libtool \
+				config.lt \
+			; do echo "/$$x"; done; \
+		fi; \
+		if test "x$(DEJATOOL)" = x; then :; else \
+			for x in \
+				$(DEJATOOL) \
+			; do echo "/$$x.sum"; echo "/$$x.log"; done; \
+			echo /site.exp; \
+		fi; \
+		if test "x$(am__dirstamp)" = x; then :; else \
+			echo "$(am__dirstamp)"; \
+		fi; \
+		if test "x$(findstring libtool,$(LTCOMPILE))" = x -a "x$(findstring libtool,$(LTCXXCOMPILE))" = x -a "x$(GTKDOC_RUN)" = x; then :; else \
+			for x in \
+				"*.lo" \
+				".libs" "_libs" \
+			; do echo "$$x"; done; \
+		fi; \
+		for x in \
+			.gitignore \
+			$(GITIGNOREFILES) \
+			$(CLEANFILES) \
+			$(PROGRAMS) $(check_PROGRAMS) $(EXTRA_PROGRAMS) \
+			$(LIBRARIES) $(check_LIBRARIES) $(EXTRA_LIBRARIES) \
+			$(LTLIBRARIES) $(check_LTLIBRARIES) $(EXTRA_LTLIBRARIES) \
+			so_locations \
+			$(MOSTLYCLEANFILES) \
+			$(TEST_LOGS) \
+			$(TEST_LOGS:.log=.trs) \
+			$(TEST_SUITE_LOG) \
+			$(TESTS:=.test) \
+			"*.gcda" \
+			"*.gcno" \
+			$(DISTCLEANFILES) \
+			$(am__CONFIG_DISTCLEAN_FILES) \
+			$(CONFIG_CLEAN_FILES) \
+			TAGS ID GTAGS GRTAGS GSYMS GPATH tags \
+			"*.tab.c" \
+			$(MAINTAINERCLEANFILES) \
+			$(BUILT_SOURCES) \
+			$(patsubst %.vala,%.c,$(filter %.vala,$(SOURCES))) \
+			$(filter %_vala.stamp,$(DIST_COMMON)) \
+			$(filter %.vapi,$(DIST_COMMON)) \
+			$(filter $(addprefix %,$(notdir $(patsubst %.vapi,%.h,$(filter %.vapi,$(DIST_COMMON))))),$(DIST_COMMON)) \
+			Makefile \
+			Makefile.in \
+			"*.orig" \
+			"*.rej" \
+			"*.bak" \
+			"*~" \
+			".*.sw[nop]" \
+			".dirstamp" \
+		; do echo "/$$x"; done; \
+		for x in \
+			"*.$(OBJEXT)" \
+			$(DEPDIR) \
+		; do echo "$$x"; done; \
+	} | \
+	sed "s@^/`echo "$(srcdir)" | sed 's/\(.\)/[\1]/g'`/@/@" | \
+	sed 's@/[.]/@/@g' | \
+	LC_ALL=C sort | uniq > $@.tmp && \
+	mv $@.tmp $@;
+
+all: $(srcdir)/.gitignore gitignore-recurse-maybe
+gitignore: $(srcdir)/.gitignore gitignore-recurse
+
+gitignore-recurse-maybe:
+	@for subdir in $(DIST_SUBDIRS); do \
+	  case " $(SUBDIRS) " in \
+	    *" $$subdir "*) :;; \
+	    *) test "$$subdir" = . -o -e "$$subdir/.git" || (cd $$subdir && $(MAKE) $(AM_MAKEFLAGS) gitignore || echo "Skipping $$subdir");; \
+	  esac; \
+	done
+gitignore-recurse:
+	@for subdir in $(DIST_SUBDIRS); do \
+	    test "$$subdir" = . -o -e "$$subdir/.git" || (cd $$subdir && $(MAKE) $(AM_MAKEFLAGS) gitignore || echo "Skipping $$subdir"); \
+	done
+
+maintainer-clean: gitignore-clean
+gitignore-clean:
+	-rm -f $(srcdir)/.gitignore
+
+.PHONY: gitignore-clean gitignore gitignore-recurse gitignore-recurse-maybe

--- a/multi-services/eks-multi-search-provider-dispatcher.c
+++ b/multi-services/eks-multi-search-provider-dispatcher.c
@@ -1,0 +1,246 @@
+/* Copyright 2018 Endless Mobile, Inc.
+ *
+ * eos-multi-services-dispatcher is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * eos-multi-services-dispatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with eos-companion-app-service.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <gio/gio.h>
+#include <glib.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+static char *opt_arch;
+static char *opt_services_version;
+
+static GOptionEntry entries[] = {
+  { "arch", 's', 0, G_OPTION_ARG_STRING, &opt_arch, "The arch to use when searching library paths with an arch-triple", "VERSION" },
+  { "services-version", 's', 0, G_OPTION_ARG_STRING, &opt_services_version, "The eks-search-provider version to use", "VERSION" },
+  { NULL }
+};
+
+static GSubprocess *
+spawnv_with_appended_paths_and_fds (const char * const  *argv,
+                                    const char * const  *executable_paths,
+                                    const char * const  *ld_library_paths,
+                                    const char * const  *xdg_data_dirs,
+                                    GError             **error)
+{
+  g_autoptr(GSubprocessLauncher) launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_INHERIT_FDS);
+  g_autofree char *executable_path_variable = g_strjoinv (":", (GStrv) executable_paths);
+  g_autofree char *ld_library_path_variable = g_strjoinv (":", (GStrv) ld_library_paths);
+  g_autofree char *xdg_data_dirs_variable = g_strjoinv (":", (GStrv) xdg_data_dirs);
+
+  g_subprocess_launcher_setenv (launcher, "PATH", executable_path_variable, TRUE);
+  g_subprocess_launcher_setenv (launcher, "LD_LIBRARY_PATH", ld_library_path_variable, TRUE);
+  g_subprocess_launcher_setenv (launcher, "XDG_DATA_DIRS", xdg_data_dirs_variable, TRUE);
+
+  return g_subprocess_launcher_spawnv (launcher, argv, error); 
+}
+
+/* Try and find an installed and mounted SDK with the highest priority,
+ * the first item having the highest priority. */
+static const char *
+find_sdk_with_highest_priority (const char * const  *sdks_in_priority_order,
+                                const char          *services_version,
+                                GError             **error)
+{
+  const char * const *iter = sdks_in_priority_order;
+
+  for (; *iter != NULL; ++iter)
+    {
+      g_autoptr(GError) local_error = NULL;
+      g_autoptr(GFile) sdk_dir = g_file_new_for_path (*iter);
+      g_autoptr(GFileEnumerator) sdk_enumerator = g_file_enumerate_children (sdk_dir,
+                                                                             G_FILE_ATTRIBUTE_STANDARD_NAME,
+                                                                             G_FILE_QUERY_INFO_NONE,
+                                                                             NULL,
+                                                                             error);
+
+      if (sdk_enumerator == NULL)
+        return NULL;
+
+      g_autoptr(GFileInfo) first_file_info = g_file_enumerator_next_file (sdk_enumerator,
+                                                                          NULL,
+                                                                          &local_error);
+
+      if (local_error != NULL)
+        {
+          g_propagate_error (error, g_steal_pointer (&local_error));
+          return NULL;
+        }
+
+      if (first_file_info != NULL)
+        return *iter;
+    }
+
+  g_set_error (error,
+               G_IO_ERROR,
+               G_IO_ERROR_FAILED,
+               "Could not find candidate SDK for services version %s",
+               services_version);
+  return NULL;
+}
+
+static void
+create_paths_for_prefixes (const char *binary,
+                           const char *sdk_prefix,
+                           const char *services_prefix,
+                           const char *arch,
+                           GStrv      *out_argv,
+                           GStrv      *out_executable_paths,
+                           GStrv      *out_ld_library_paths,
+                           GStrv      *out_xdg_data_dirs)
+{
+  g_autoptr(GPtrArray) argv = g_ptr_array_new_with_free_func (g_free);
+  g_autoptr(GPtrArray) executable_paths = g_ptr_array_new_with_free_func (g_free);
+  g_autoptr(GPtrArray) ld_library_paths = g_ptr_array_new_with_free_func (g_free);
+  g_autoptr(GPtrArray) xdg_data_dirs = g_ptr_array_new_with_free_func (g_free);
+
+  g_ptr_array_add (argv, g_build_filename (services_prefix, "bin", binary, NULL));
+  g_ptr_array_add (argv, NULL);
+
+  g_ptr_array_add (executable_paths, g_build_filename (services_prefix, "bin", NULL));
+  g_ptr_array_add (executable_paths, g_build_filename (sdk_prefix, "bin", NULL));
+  g_ptr_array_add (executable_paths, NULL);
+
+  g_ptr_array_add (ld_library_paths, g_build_filename (services_prefix, "lib", NULL));
+  g_ptr_array_add (ld_library_paths, g_build_filename (sdk_prefix, "lib", NULL));
+
+  /* If we specified an arch, also add an arch-triple library path */
+  if (arch != NULL)
+    {
+      g_autofree char *arch_triple = g_strdup_printf ("%s-linux-gnu", arch);
+      g_ptr_array_add (ld_library_paths,
+                       g_build_filename (sdk_prefix, "lib", arch_triple, NULL));
+    }
+
+  g_ptr_array_add (ld_library_paths, NULL);
+
+  g_ptr_array_add (xdg_data_dirs, g_build_filename (services_prefix, "share", NULL));
+  g_ptr_array_add (xdg_data_dirs, g_build_filename (sdk_prefix, "share", NULL));
+  g_ptr_array_add (xdg_data_dirs, NULL);
+
+  *out_argv = (GStrv) g_ptr_array_free (g_steal_pointer (&argv), FALSE);
+  *out_executable_paths = (GStrv) g_ptr_array_free (g_steal_pointer (&executable_paths), FALSE);
+  *out_ld_library_paths = (GStrv) g_ptr_array_free (g_steal_pointer (&ld_library_paths), FALSE);
+  *out_xdg_data_dirs = (GStrv) g_ptr_array_free (g_steal_pointer (&xdg_data_dirs), FALSE);
+}
+
+static gboolean
+dispatch_correct_service (const char   *services_version,
+                          const char   *arch,
+                          GError      **error)
+{
+  /* We keep track of this and then free it, the exec'd service
+   * will become a child of init and inherit all our fds, thus
+   * consuming the d-bus traffic that was destined for this process. */
+  g_autoptr(GSubprocess) subprocess = NULL;
+
+  g_auto(GStrv) argv = NULL;
+  g_auto(GStrv) executable_paths = NULL;
+  g_auto(GStrv) ld_library_paths = NULL;
+  g_auto(GStrv) xdg_data_dirs = NULL;
+
+  if (g_strcmp0 (services_version, "1") == 0)
+    {
+      const char * const candidate_sdks[] = {
+        "/app/sdk/1",
+        "/app/sdk/0",
+        NULL
+      };
+      const char *sdk_path = find_sdk_with_highest_priority (candidate_sdks,
+                                                             services_version,
+                                                             error);
+
+      if (sdk_path == NULL)
+        return FALSE;
+
+      create_paths_for_prefixes ("eks-search-provider-v1",
+                                 sdk_path,
+                                 "/app/eos-knowledge-services/1",
+                                 arch,
+                                 &argv,
+                                 &executable_paths,
+                                 &ld_library_paths,
+                                 &xdg_data_dirs);
+    }
+  else if (g_strcmp0 (services_version, "2") == 0)
+    {
+      const char * const candidate_sdks[] = {
+        "/app/sdk/3",
+        "/app/sdk/2",
+        NULL
+      };
+      const char *sdk_path = find_sdk_with_highest_priority (candidate_sdks,
+                                                             services_version,
+                                                             error);
+
+      if (sdk_path == NULL)
+        return FALSE;
+
+      create_paths_for_prefixes ("eks-search-provider-v2",
+                                 sdk_path,
+                                 "/app/eos-knowledge-services/2",
+                                 arch,
+                                 &argv,
+                                 &executable_paths,
+                                 &ld_library_paths,
+                                 &xdg_data_dirs);
+    }
+  else
+    {
+      g_set_error (error,
+                   G_IO_ERROR,
+                   G_IO_ERROR_FAILED,
+                   "Don't know how to spawn services version %s",
+                   services_version);
+      return FALSE;
+    }
+
+  subprocess = spawnv_with_appended_paths_and_fds ((const char * const *) argv,
+                                                   (const char * const *) executable_paths,
+                                                   (const char * const *) ld_library_paths,
+                                                   (const char * const *) xdg_data_dirs,
+                                                   error);
+  return subprocess != NULL;
+}
+
+int
+main (int    argc,
+      char **argv)
+{
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GOptionContext) context = g_option_context_new ("- multiplexer for EknServices");
+
+  g_option_context_add_main_entries (context, entries, NULL);
+
+  if (!g_option_context_parse (context, &argc, &argv, &local_error))
+    {
+      g_message ("Option parsing failed: %s\n", local_error->message);
+      return EXIT_FAILURE;
+    }
+
+  if (!dispatch_correct_service (opt_services_version,
+                                 opt_arch,
+                                 &local_error))
+    {
+      g_message ("Failed to dispatch correct service for version %s: %s",
+                 opt_services_version,
+                 local_error->message);
+      return EXIT_FAILURE;
+    }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This actually adds two build manifests. The first,
com.endlessm.BaseEknServicesMultiplexer is a "base" flatpak which merely
adds the extension points for the extensions defined in each
eos-knowledge-services version (eg, com.endlessm.EknSerivces.Extension).

That flatpak is then used as a "base" for com.endlessm.EknServicesMultiplexer
which will get those extensions mounted at build-time so that we can copy
their contents into the right place in com.endlessm.EknServicesMultiplexer.

com.endlessm.EknServicesMultiplexer itself is made up of a few things. First,
it mounts every available SDK as an extension using the flatpak "tagged extension
names" feature introduced in flatpak 0.11.4. Second, it exports the d-bus service
files for each eos-knowledge-services version, all of which point to a "multiplexer"
binary.

The "multiplexer" binary (eks-multi-services-dispatcher) takes a single argument,
--services-version and uses that to try and find the highest-versioned compatible
SDK and sets LD_LIBRARY_PATH and friends, then executes the correct eks-search-provider
binary that was copied in place at build time.

https://phabricator.endlessm.com/T21822