### PR TITLE
data: Add no-a11y-bus to X-Flatpak-RunOptions

### DIFF
--- a/data/com.endlessm.EknServices.SearchProviderV1.service.in
+++ b/data/com.endlessm.EknServices.SearchProviderV1.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices.SearchProviderV1
 Exec=%bindir%/eks-multi-search-provider-dispatcher --services-version 1 --arch %arch%
+X-Flatpak-RunOptions=no-a11y-bus

--- a/data/com.endlessm.EknServices.SearchProviderV1.service.in
+++ b/data/com.endlessm.EknServices.SearchProviderV1.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices.SearchProviderV1
 Exec=%bindir%/eks-multi-search-provider-dispatcher --services-version 1 --arch %arch%
-X-Flatpak-RunOptions=no-a11y-bus
+X-Flatpak-RunOptions=no-a11y-bus;no-documents-portal

--- a/data/com.endlessm.EknServices2.SearchProviderV2.service.in
+++ b/data/com.endlessm.EknServices2.SearchProviderV2.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices2.SearchProviderV2
 Exec=%bindir%/eks-multi-search-provider-dispatcher --services-version 2 --arch %arch%
-X-Flatpak-RunOptions=no-a11y-bus
+X-Flatpak-RunOptions=no-a11y-bus;no-documents-portal

--- a/data/com.endlessm.EknServices2.SearchProviderV2.service.in
+++ b/data/com.endlessm.EknServices2.SearchProviderV2.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices2.SearchProviderV2
 Exec=%bindir%/eks-multi-search-provider-dispatcher --services-version 2 --arch %arch%
+X-Flatpak-RunOptions=no-a11y-bus

--- a/data/com.endlessm.EknServices3.SearchProviderV3.service.in
+++ b/data/com.endlessm.EknServices3.SearchProviderV3.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices3.SearchProviderV3
 Exec=%bindir%/eks-multi-search-provider-dispatcher --services-version 3 --arch %arch%
-X-Flatpak-RunOptions=no-a11y-bus
+X-Flatpak-RunOptions=no-a11y-bus;no-documents-portal

--- a/data/com.endlessm.EknServices3.SearchProviderV3.service.in
+++ b/data/com.endlessm.EknServices3.SearchProviderV3.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=com.endlessm.EknServices3.SearchProviderV3
 Exec=%bindir%/eks-multi-search-provider-dispatcher --services-version 3 --arch %arch%
+X-Flatpak-RunOptions=no-a11y-bus


### PR DESCRIPTION
Similar to the changes done in eos-knowledge-services already, we
don't want to autostart the a11y daemons on a non-user session.

https://phabricator.endlessm.com/T22088