### PR TITLE
Support aarch64 builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,18 +23,9 @@ EXTRA_DIST =
 # # # SUBSTITUTED FILES # # #
 # These files need to be filled in with make variables
 do_subst = $(SED) -e 's|%bindir%|$(bindir)|g' -e 's|%arch%|$(UNAME_ARCH)|g'
-subst_files = \
-	data/com.endlessm.EknServices.SearchProviderV1.service \
-	data/com.endlessm.EknServices2.SearchProviderV2.service \
-	data/com.endlessm.EknServices3.SearchProviderV3.service \
-	$(NULL)
-
-$(subst_files): %: %.in Makefile
+%: %.in Makefile
 	$(AM_V_GEN)$(MKDIR_P) $(@D) && \
 	$(do_subst) $< > $@
-
-CLEANFILES += $(subst_files)
-EXTRA_DIST += $(patsubst %,%.in,$(subst_files))
 
 bin_PROGRAMS = eks-multi-search-provider-dispatcher
 eks_multi_search_provider_dispatcher_SOURCES = \
@@ -51,10 +42,19 @@ eks_multi_search_provider_dispatcher_LDADD = \
 
 servicedir = $(datadir)/dbus-1/services
 service_DATA = \
-	data/com.endlessm.EknServices.SearchProviderV1.service \
-	data/com.endlessm.EknServices2.SearchProviderV2.service \
 	data/com.endlessm.EknServices3.SearchProviderV3.service \
 	$(NULL)
+
+# EknServices 1 & 2 not provided by newer architectures
+if COMPAT_ARCH
+service_DATA += \
+	data/com.endlessm.EknServices.SearchProviderV1.service \
+	data/com.endlessm.EknServices2.SearchProviderV2.service \
+	$(NULL)
+endif
+
+CLEANFILES += $(service_DATA)
+EXTRA_DIST += $(patsubst %,%.in,$(service_DATA))
 
 -include $(top_srcdir)/git.mk
 

--- a/com.endlessm.BaseEknServicesMultiplexer.json.in.in
+++ b/com.endlessm.BaseEknServicesMultiplexer.json.in.in
@@ -5,14 +5,6 @@
     "runtime-version": "5",
     "sdk": "com.endlessm.apps.Sdk",
     "add-extensions": {
-        "com.endlessm.EknServices.Extension": {
-            "directory": "build/eos-knowledge-services/1",
-            "version": "eos3"
-        },
-        "com.endlessm.EknServices2.Extension": {
-            "directory": "build/eos-knowledge-services/2",
-            "version": "stable"
-        },
         "com.endlessm.EknServices3.Extension": {
             "directory": "build/eos-knowledge-services/3",
             "version": "@BRANCH@"
@@ -23,8 +15,6 @@
             "name": "multi-eos-knowledge-services-directories",
             "buildsystem": "simple",
             "build-commands": [
-                "mkdir -p /app/build/eos-knowledge-services/1",
-                "mkdir -p /app/build/eos-knowledge-services/2",
                 "mkdir -p /app/build/eos-knowledge-services/3"
             ]
         }

--- a/com.endlessm.EknServicesMultiplexer.json.in.in
+++ b/com.endlessm.EknServicesMultiplexer.json.in.in
@@ -2,8 +2,6 @@
     "app-id": "com.endlessm.EknServicesMultiplexer",
     "base": "com.endlessm.BaseEknServicesMultiplexer",
     "base-extensions": [
-        "com.endlessm.EknServices.Extension",
-        "com.endlessm.EknServices2.Extension",
         "com.endlessm.EknServices3.Extension"
     ],
     "branch": "@BRANCH@",
@@ -18,36 +16,9 @@
         "--env=EKN_SUBSCRIPTIONS_DIR=.local/share/com.endlessm.subscriptions",
         "--share=network",
         "--socket=session-bus",
-        "--own-name=com.endlessm.EknServices.SearchProviderV1",
-        "--own-name=com.endlessm.EknServices2.SearchProviderV2",
         "--own-name=com.endlessm.EknServices3.SearchProviderV3"
     ],
     "add-extensions": {
-        "com.endlessm.Platform": {
-            "directory": "sdk/0",
-            "no-autodownload": true,
-            "versions": "eos3.1;eos3.0"
-        },
-        "com.endlessm.apps.Platform@1": {
-            "directory": "sdk/1",
-            "no-autodownload": true,
-            "version": "1"
-        },
-        "com.endlessm.apps.Platform@2": {
-            "directory": "sdk/2",
-            "no-autodownload": true,
-            "version": "2"
-        },
-        "com.endlessm.apps.Platform@3": {
-            "directory": "sdk/3",
-            "no-autodownload": true,
-            "version": "3"
-        },
-        "com.endlessm.apps.Platform": {
-            "directory": "sdk/4",
-            "no-autodownload": true,
-            "version": "4"
-        },
         "com.endlessm.apps.Platform": {
             "directory": "sdk/5",
             "no-autodownload": true,
@@ -69,20 +40,9 @@
             "name": "multi-eos-knowledge-services-directories",
             "buildsystem": "simple",
             "build-commands": [
-                "mkdir -p /app/sdk/0",
-                "mkdir -p /app/sdk/1",
-                "mkdir -p /app/sdk/2",
-                "mkdir -p /app/sdk/3",
-                "mkdir -p /app/sdk/4",
                 "mkdir -p /app/sdk/5",
                 "mkdir -p /app/eos-knowledge-services/",
                 "mkdir -p /app/lib/debug/eos-knowledge-services",
-                "cp -r /app/build/eos-knowledge-services/1 /app/eos-knowledge-services/1",
-                "mv /app/eos-knowledge-services/1/lib/debug /app/lib/debug/eos-knowledge-services/1",
-                "ln -s /app/eos-knowledge-services/1/bin/eks-search-provider-v1 /app/bin/eks-search-provider-v1",
-                "cp -r /app/build/eos-knowledge-services/2 /app/eos-knowledge-services/2",
-                "mv /app/eos-knowledge-services/2/lib/debug /app/lib/debug/eos-knowledge-services/2",
-                "ln -s /app/eos-knowledge-services/2/bin/eks-search-provider-v2 /app/bin/eks-search-provider-v2",
                 "cp -r /app/build/eos-knowledge-services/3 /app/eos-knowledge-services/3",
                 "mv /app/eos-knowledge-services/3/lib/debug /app/lib/debug/eos-knowledge-services/3",
                 "ln -s /app/eos-knowledge-services/3/bin/eks-search-provider-v3 /app/bin/eks-search-provider-v3"

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,24 @@ PKG_PROG_PKG_CONFIG
 UNAME_ARCH=$(uname -p)
 AC_SUBST([UNAME_ARCH])
 
+# Newer arches will only build EknServices 3. Figure out what to do
+# based on the architecture. flatpak-builder sets FLATPAK_ARCH.
+# Otherwise, use flatpak --default-arch for local testing.
+AC_ARG_VAR([FLATPAK_ARCH], [Flatpak architecture])
+if test -z "$FLATPAK_ARCH"; then
+  FLATPAK_ARCH=$(flatpak --default-arch)
+fi
+case "$FLATPAK_ARCH" in
+  x86_64|arm)
+    COMPAT_ARCH=y
+    AC_DEFINE([COMPAT_ARCH], [1], [Arch providing EknServices 1 and 2])
+    ;;
+  *)
+    COMPAT_ARCH=n
+    ;;
+esac
+AM_CONDITIONAL([COMPAT_ARCH], [test "$COMPAT_ARCH" = y])
+
 # Only need glib and gio for the multi-services binary
 PKG_CHECK_MODULES([MULTI_SERVICES], [
   gio-2.0
@@ -68,7 +86,7 @@ AC_CACHE_SAVE
 # Output
 # ------
 # List files here that the configure script should output
-
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
   Makefile
 ])

--- a/generate-manifests
+++ b/generate-manifests
@@ -1,0 +1,140 @@
+#!/usr/bin/python3
+
+from argparse import ArgumentParser
+import json
+import os
+import subprocess
+
+PROGDIR = os.path.dirname(__file__)
+BASE_TEMPLATE = os.path.join(
+    PROGDIR, 'com.endlessm.BaseEknServicesMultiplexer.json.in.in')
+BASE_OUTPUT = os.path.splitext(BASE_TEMPLATE)[0]
+MULTIPLEXER_TEMPLATE = os.path.join(
+    PROGDIR, 'com.endlessm.EknServicesMultiplexer.json.in.in')
+MULTIPLEXER_OUTPUT = os.path.splitext(MULTIPLEXER_TEMPLATE)[0]
+DIRECTORIES_MODULE_NAME = 'multi-eos-knowledge-services-directories'
+COMPAT_ARCHES = [
+    'x86_64',
+    'arm',
+]
+
+
+def generate_base_manifest(arch):
+    with open(BASE_TEMPLATE, 'r') as f:
+        manifest = json.load(f)
+
+    # Newer architectures don't provide EknServices 1 & 2 extensions
+    if arch in COMPAT_ARCHES:
+        manifest['add-extensions'].update({
+            'com.endlessm.EknServices.Extension': {
+                'directory': 'build/eos-knowledge-services/1',
+                'version': 'eos3',
+            },
+            'com.endlessm.EknServices2.Extension': {
+                'directory': 'build/eos-knowledge-services/2',
+                'version': 'stable',
+            },
+        })
+
+        directories_module = None
+        for module in manifest['modules']:
+            if module['name'] == DIRECTORIES_MODULE_NAME:
+                directories_module = module
+                break
+        if directories_module is None:
+            raise Exception(f'Could not find module {DIRECTORIES_MODULE_NAME}')
+        directories_module['build-commands'] += [
+            'mkdir -p /app/build/eos-knowledge-services/1',
+            'mkdir -p /app/build/eos-knowledge-services/2',
+        ]
+
+    with open(BASE_OUTPUT, 'w') as f:
+        json.dump(manifest, f, indent=4)
+
+
+def generate_multiplexer_manifest(arch):
+    with open(MULTIPLEXER_TEMPLATE, 'r') as f:
+        manifest = json.load(f)
+
+    # Newer architectures don't provide EknServices 1 & 2 extensions or
+    # SDK versions before 5.
+    if arch in COMPAT_ARCHES:
+        manifest['base-extensions'] += [
+            'com.endlessm.EknServices.Extension',
+            'com.endlessm.EknServices2.Extension',
+        ]
+        manifest['finish-args'] += [
+            '--own-name=com.endlessm.EknServices.SearchProviderV1',
+            '--own-name=com.endlessm.EknServices2.SearchProviderV2',
+        ]
+        manifest['add-extensions'].update({
+            'com.endlessm.Platform': {
+                'directory': 'sdk/0',
+                'no-autodownload': True,
+                'versions': 'eos3.1;eos3.0',
+            },
+            'com.endlessm.apps.Platform@1': {
+                'directory': 'sdk/1',
+                'no-autodownload': True,
+                'version': '1',
+            },
+            'com.endlessm.apps.Platform@2': {
+                'directory': 'sdk/2',
+                'no-autodownload': True,
+                'version': '2',
+            },
+            'com.endlessm.apps.Platform@3': {
+                'directory': 'sdk/3',
+                'no-autodownload': True,
+                'version': '3',
+            },
+            'com.endlessm.apps.Platform': {
+                'directory': 'sdk/4',
+                'no-autodownload': True,
+                'version': '4'
+            },
+        })
+
+        directories_module = None
+        for module in manifest['modules']:
+            if module['name'] == DIRECTORIES_MODULE_NAME:
+                directories_module = module
+                break
+        if directories_module is None:
+            raise Exception(f'Could not find module {DIRECTORIES_MODULE_NAME}')
+
+        directories_build_commands = directories_module['build-commands']
+        directories_build_commands += [f'mkdir -p /app/sdk/{version}'
+                                       for version in range(1, 5)]
+        for version in range(1, 3):
+            directories_build_commands += [
+                ('cp -r /app/build/eos-knowledge-services/{v} '
+                 '/app/eos-knowledge-services/{v}'
+                 .format(v=version)),
+                ('mv /app/eos-knowledge-services/{v}/lib/debug '
+                 '/app/lib/debug/eos-knowledge-services/{v}'
+                 .format(v=version)),
+                ('ln -s '
+                 '/app/eos-knowledge-services/{v}/bin/eks-search-provider-v{v} '
+                 '/app/bin/eks-search-provider-v{v}'
+                 .format(v=version)),
+            ]
+
+    with open(MULTIPLEXER_OUTPUT, 'w') as f:
+        json.dump(manifest, f, indent=4)
+
+
+ap = ArgumentParser(
+    description='Generate EknServicesMultiplexer manifests'
+)
+ap.add_argument('--arch', default=os.getenv('FLATPAK_ARCH'),
+                help='flatpak architecture')
+args = ap.parse_args()
+
+if args.arch is None:
+    # Use flatpak --default-arch for local testing
+    cmd = ('flatpak', '--default-arch')
+    args.arch = subprocess.check_output(cmd).decode('utf-8').strip()
+
+generate_base_manifest(args.arch)
+generate_multiplexer_manifest(args.arch)

--- a/multi-services/eks-multi-search-provider-dispatcher.c
+++ b/multi-services/eks-multi-search-provider-dispatcher.c
@@ -15,6 +15,10 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <gio/gio.h>
 #include <glib.h>
 
@@ -153,6 +157,8 @@ dispatch_correct_service (const char   *services_version,
   g_auto(GStrv) ld_library_paths = NULL;
   g_auto(GStrv) xdg_data_dirs = NULL;
 
+  /* EknServices 1 & 2 not provided by newer architecures. */
+#ifdef COMPAT_ARCH
   if (g_strcmp0 (services_version, "1") == 0)
     {
       const char * const candidate_sdks[] = {
@@ -199,7 +205,9 @@ dispatch_correct_service (const char   *services_version,
                                  &ld_library_paths,
                                  &xdg_data_dirs);
     }
-  else if (g_strcmp0 (services_version, "3") == 0)
+  else
+#endif /* COMPAT_ARCH */
+  if (g_strcmp0 (services_version, "3") == 0)
     {
       const char * const candidate_sdks[] = {
         "/app/sdk/5",


### PR DESCRIPTION
For newer architectures such as aarch64, we have no intention of building and releasing EknServices 1 & 2 or and SDK versions before 5. Define x86_64 and arm as "compat" architectures and only handle these older extension points in those cases.

https://phabricator.endlessm.com/T27755