### PR TITLE
De-conflict SDK 4 and 5 extension names

### DIFF
--- a/generate-manifests
+++ b/generate-manifests
@@ -88,7 +88,7 @@ def generate_multiplexer_manifest(arch):
                 'no-autodownload': True,
                 'version': '3',
             },
-            'com.endlessm.apps.Platform': {
+            'com.endlessm.apps.Platform@4': {
                 'directory': 'sdk/4',
                 'no-autodownload': True,
                 'version': '4'


### PR DESCRIPTION
When the SDK5 extension was added, it used the same bare
`com.endlessm.apps.Platform` name as the previous SDK4 entry. Since
`add-extensions` is defined as a dictionary, only one entry could be
kept.

Previously when the extensions were all defined inline in the JSON
template, SDK4 was thrown away. When the manifest was changed to be
updated from a script to support newer architectures that don't have
SDK4 or older, SDK5 was thrown away.

Suffix the SDK4 extension name like for SDK3 and earlier so it doesn't
conflict with the SDK5 extension name.

https://phabricator.endlessm.com/T29113