### PR TITLE
Remove bundle data from appstream metainfo

### DIFF
--- a/com.endlessm.BaseEknServicesMultiplexer.metainfo.xml.in
+++ b/com.endlessm.BaseEknServicesMultiplexer.metainfo.xml.in
@@ -8,5 +8,4 @@
   <summary>Extension points for Endless Desktop Search</summary>
   <url type="homepage">https://endlessos.com/</url>
   <project_group>Endless</project_group>
-  <bundle type="flatpak" runtime="com.endlessm.apps.Platform/@ARCH@/@SDK_BRANCH@" sdk="com.endlessm.apps.Sdk/@ARCH@/@SDK_BRANCH@">runtime/com.endlessm.BaseEknServicesMultiplexer/@ARCH@/@BRANCH@</bundle>
 </component>

--- a/com.endlessm.EknServicesMultiplexer.metainfo.xml.in
+++ b/com.endlessm.EknServicesMultiplexer.metainfo.xml.in
@@ -7,5 +7,4 @@
   <summary>Desktop search provider for Endless applications</summary>
   <url type="homepage">https://endlessos.com/</url>
   <project_group>Endless</project_group>
-  <bundle type="flatpak" runtime="com.endlessm.apps.Platform/@ARCH@/@SDK_BRANCH@" sdk="com.endlessm.apps.Sdk/@ARCH@/@SDK_BRANCH@">runtime/com.endlessm.EknServicesMultiplexer/@ARCH@/@BRANCH@</bundle>
 </component>


### PR DESCRIPTION
On older flatpak as used in our infrastructure this causes a segfault
when `flatpak build-update-repo` tries to construct the global appstream
XML. As it turns out, flatpak tries to throw out any `<bundle>` nodes it
finds and always constructs a new one based on the flatpak metadata. So,
even though this information is correct, it's ignored. With this change
(wrapped for clarity):

```
$ ostree cat appstream2/x86_64 /appstream.xml | grep bundle
    <bundle type="flatpak" runtime="com.endlessm.apps.Platform/x86_64/5"
      sdk="com.endlessm.apps.Sdk/x86_64/5">
      app/com.endlessm.BaseEknServicesMultiplexer/x86_64/master
    </bundle>
```

https://phabricator.endlessm.com/T30093