### PR TITLE
appdata: Add OARS content rating and description

### DIFF
--- a/com.endlessm.EknServicesMultiplexer.metainfo.xml.in
+++ b/com.endlessm.EknServicesMultiplexer.metainfo.xml.in
@@ -7,4 +7,5 @@
   <summary>Desktop search provider for Endless applications</summary>
   <url type="homepage">https://endlessos.com/</url>
   <project_group>Endless</project_group>
+  <content_rating type="oars-1.1" />
 </component>

--- a/com.endlessm.EknServicesMultiplexer.metainfo.xml.in
+++ b/com.endlessm.EknServicesMultiplexer.metainfo.xml.in
@@ -5,6 +5,9 @@
   <project_license>LGPL-2.1+</project_license>
   <name>Endless Desktop Search</name>
   <summary>Desktop search provider for Endless applications</summary>
+  <description>
+    <p>When you type to search on the desktop, Endless Desktop Search finds results from applications on your computer such as Encyclopedia.</p>
+  </description>
   <url type="homepage">https://endlessos.com/</url>
   <project_group>Endless</project_group>
   <content_rating type="oars-1.1" />

--- a/com.endlessm.EknServicesMultiplexer.metainfo.xml.in
+++ b/com.endlessm.EknServicesMultiplexer.metainfo.xml.in
@@ -9,6 +9,7 @@
     <p>When you type to search on the desktop, Endless Desktop Search finds results from applications on your computer such as Encyclopedia.</p>
   </description>
   <url type="homepage">https://endlessos.com/</url>
+  <update_contact>apps-platform@endlessm.com</update_contact>
   <project_group>Endless</project_group>
   <content_rating type="oars-1.1" />
 </component>

--- a/com.endlessm.EknServicesMultiplexer.metainfo.xml.in
+++ b/com.endlessm.EknServicesMultiplexer.metainfo.xml.in
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2020 Endless OS Foundation LLC -->
 <component type="generic">
   <id>com.endlessm.EknServicesMultiplexer</id>
   <metadata_license>CC0</metadata_license>


### PR DESCRIPTION
This app does nothing OARSable in and of itself. Of course, you might have objectionable content installed, in which case it would return it, but that's not the multiplexer's fault.

Providing OARS data prevents it being hidden if the user has parental controls applied. While I'm here, let's add a description.

https://phabricator.endlessm.com/T30745
