### PR TITLE
Revert "Add permission to read from /run/flatpak"

### DIFF
--- a/com.endlessm.EknServicesMultiplexer.json.in
+++ b/com.endlessm.EknServicesMultiplexer.json.in
@@ -7,7 +7,6 @@
     "runtime-version": "@SDK_BRANCH@",
     "sdk": "com.endlessm.apps.Sdk",
     "finish-args": [
-        "--filesystem=/run/flatpak:ro",
         "--filesystem=/var/lib/flatpak:ro",
         "--filesystem=/var/endless-extra/flatpak:ro",
         "--filesystem=~/.local/share/flatpak:ro",


### PR DESCRIPTION
This reverts commit 7b930b3f741ed5517acbc619e0d826c5f2769cad.

Flatpak 1.12 attempts to bind-mount stuff into /run/flatpak, since
https://github.com/flatpak/flatpak/commit/40510e8ae8fd433df04959938b8e81e582849481,
which interacts poorly with this sandbox hole and prevents the app from
starting.

The sandbox hole is no longer needed because we no longer ship USB keys
where encyclopedia content is stored outside the Endless OS filesystem.
If we did want to restore support for this in future, I believe it would
be sufficient to use '--filesystem=/run/flatpak/extensions' instead.

https://phabricator.endlessm.com/T33181
